### PR TITLE
Fix #70 projectiles issues

### DIFF
--- a/Binaries/Win64/UE4Editor-OpenTournament.dll
+++ b/Binaries/Win64/UE4Editor-OpenTournament.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5816ba724477ebda42dd673c01b30f6f46b86768f5d2724ad7bc66d4120c0bff
-size 1873920
+oid sha256:f8a09a40c7ba36d137b0a3e258e4594c93ee5b30748c03e70424e7cc14b45c60
+size 1875968

--- a/Source/OpenTournament/UR_Projectile.h
+++ b/Source/OpenTournament/UR_Projectile.h
@@ -167,11 +167,11 @@ protected:
     UPROPERTY(ReplicatedUsing = OnRep_ServerExplosionInfo)
     FReplicatedExplosionInfo ServerExplosionInfo;
 
+    UPROPERTY()
+    float ClientExplosionTime;
+
     UFUNCTION()
-    void OnRep_ServerExplosionInfo()
-    {
-        Explode(ServerExplosionInfo.HitLocation, ServerExplosionInfo.HitNormal);
-    }
+    virtual void OnRep_ServerExplosionInfo();
 
     /////////////////////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
When projectiles have `bNetTemporary=true`, they only replicate spawning, but replication link is cut right away.
This is the simplest case, client is fully responsible for exploding/destroying projectile on its own.
This is suited for all spammable, less important projectiles.
It can be set in Blueprints through the `bCutReplicationAfterSpawn` property.

This mechanism is however not suited for projectiles that may need to be updated from server, such as interactive projectiles, or simply the more prominent projectiles where we want a more accurate simulation.
In that case, when projectile explodes on server, we replicate explosion info to correct client's simulation if necessary. This has the following purposes :
- Projectile may be detonated by user (combo or C4 type firemode), this cannot be predicted by other clients simulations.
- Projectile may hit something on server which it did not hit on client. Replication of explosion will correct that very quickly instead of letting projectile continue its flight on client machine (and generate unreg later on).
- Projectile may hit on client but not on server (typical unreg case), which we can detect due to the lack of explosion replication.

This replication of explosion leads to 4 potential cases to handle when dealing with client-side explosion :

**(1) Explode on client before receiving server explosion**
--> Play explosion, hide projectile, and wait for server confirmation.
--> We will either receive server explosion soon (confirm case), or much later (unreg case).

**(2) Explode on client after receiving server explosion**
--> This should not happen if we properly disable simulation in case (3).

**(3) Receive server explosion before exploded on client**
--> Play explosion, stop simulating and destroy when possible.
(note: client cannot destroy as long as replication link exists)

**(4) Receive server explosion after exploded on client**
--> As per case (1), this is either a confirmation, or an unreg case.
--> In unreg case, we should replay the real explosion at the proper location.
