### PR TITLE
Bugfix: OT-#75 : Bug: Pickup Classes Don't Respond to Character Overl…

### DIFF
--- a/Source/OpenTournament/UR_AmmoPickup.cpp
+++ b/Source/OpenTournament/UR_AmmoPickup.cpp
@@ -5,6 +5,8 @@
 #include "UR_AmmoPickup.h"
 
 #include "OpenTournament.h"
+#include "UR_Character.h"
+#include "UR_InventoryComponent.h"
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -14,6 +16,35 @@ AUR_AmmoPickup::AUR_AmmoPickup(const FObjectInitializer& ObjectInitializer) :
     AmmoValue(10)
 {
     DisplayName = FString("Ammo");
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+void AUR_AmmoPickup::OnPickup_Implementation(AUR_Character* PickupCharacter)
+{
+    Super::OnPickup_Implementation(PickupCharacter);
+
+    // @! TODO : Probably preferable to handle this via GameplayEffect in order to reduce custom logic in pickup class.
+    if (PickupCharacter && WeaponClass)
+    {
+        if (const auto InventoryComponent = PickupCharacter->InventoryComponent)
+        {
+            for (auto& Weapon : InventoryComponent->InventoryW)
+            {
+                if (WeaponClass == Weapon->GetClass())
+                {
+                    // @! TODO : Confusing/Bad Weapon-Ammo API here.
+                    Weapon->ConsumeAmmo(-1 * AmmoValue);
+
+                    // @! TODO : No AmmoMax value currently (and we probably shouldn't do this here. But stubbed just in case)
+                    //if (Weapon->GetCurrentAmmo() > Weapon->AmmoMax)
+                    //{
+                    //    Weapon->AmmoCount = Weapon->AmmoMax;
+                    //}
+                }
+            }
+        }
+    }
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/OpenTournament/UR_AmmoPickup.h
+++ b/Source/OpenTournament/UR_AmmoPickup.h
@@ -30,6 +30,8 @@ public:
 
     /////////////////////////////////////////////////////////////////////////////////////////////////
 
+    void OnPickup_Implementation(AUR_Character* PickupCharacter) override;
+    
     /**
     * * @! TODO : This doesn't account for weapons that might have more than one
     *           type of ammunition (e.g. Bullets + Grenades, etc).

--- a/Source/OpenTournament/UR_Pickup.cpp
+++ b/Source/OpenTournament/UR_Pickup.cpp
@@ -25,7 +25,7 @@ AUR_Pickup::AUR_Pickup(const FObjectInitializer& ObjectInitializer) :
     CollisionComponent->SetCapsuleSize(20.f, 20.f, true);
     CollisionComponent->Mobility = EComponentMobility::Static;
     CollisionComponent->SetCollisionResponseToAllChannels(ECollisionResponse::ECR_Ignore);
-    CollisionComponent->SetCollisionResponseToChannel(ECollisionChannel::ECC_Pawn, ECollisionResponse::ECR_Ignore);
+    CollisionComponent->SetCollisionResponseToChannel(ECollisionChannel::ECC_Pawn, ECollisionResponse::ECR_Overlap);
 
     RootComponent = CollisionComponent;
 
@@ -113,7 +113,7 @@ void AUR_Pickup::OnPickup_Implementation(AUR_Character* PickupCharacter)
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-void AUR_Pickup::SetPickupState(EPickupState NewState)
+void AUR_Pickup::SetPickupState(const EPickupState NewState)
 {
     if (PickupState == NewState)
     {
@@ -140,5 +140,7 @@ void AUR_Pickup::SetPickupState(EPickupState NewState)
 
 void AUR_Pickup::RespawnPickup()
 {
+    UGameplayStatics::PlaySoundAtLocation(GetWorld(), RespawnSound, GetActorLocation());
+
     SetPickupState(EPickupState::Active);
 }


### PR DESCRIPTION
…ap & OT-#76 : Bug: Ammo Pickup Classes Don't Perform Any Action (#77)

* Bugfix OT-#75 : Pickup Don't Respond to Overlap

- Fixed erroneous CollisionComponent ignoring of Pawn, when should have overlapped

* Bugfix OT-#76 : AmmoPickup Don't Perform Action

- Added C++ functionality for granting Ammo to specified WeaponClass

Co-authored-by: Blue Cloud <BluestCloud@users.noreply.github.com>
Co-authored-by: OpenTournament <64699908+OpenTournament@users.noreply.github.com>