### PR TITLE
fix #202 game crash when launching standalone (non-PIE)

### DIFF
--- a/Binaries/Win64/UE4Editor-OpenTournament.dll
+++ b/Binaries/Win64/UE4Editor-OpenTournament.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2ba5315ee2c8c545e3aad4f03d3ff0cbee2c142b18a47e44355f1a5484c39b99
-size 2189312
+oid sha256:8eded42eab4f033a569a0e798157c9013b14037109649166992d66cb1b6d35ac
+size 2187264

--- a/Source/OpenTournament/UR_PickupFactory.cpp
+++ b/Source/OpenTournament/UR_PickupFactory.cpp
@@ -48,8 +48,11 @@ AUR_PickupFactory::AUR_PickupFactory()
     AttachComponent = NULL;
 
     EditorPreview = CreateEditorOnlyDefaultSubobject<UStaticMeshComponent>(TEXT("EditorPreview"), true);
-    EditorPreview->SetupAttachment(RootComponent);
-    EditorPreview->SetHiddenInGame(true);
+    if (EditorPreview != NULL)
+    {
+        EditorPreview->SetupAttachment(RootComponent);
+        EditorPreview->SetHiddenInGame(true);
+    }
 
     RotationRate = 180;
     BobbingHeight = 0;


### PR DESCRIPTION
An editor-only component was not checked for null.